### PR TITLE
wroskflows: build: Enable cross by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          use-cross: startWith($${{ matrix.target }}, 'x86') != true
+          use-cross: true
           args: --release --locked --target=${{ matrix.target }}
 
       - name: Package


### PR DESCRIPTION
It appears that ${{true}} fails to set use-cross as true.
Using cross by default will take a bit longer, but at least will fix
the build problem.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>