### PR TITLE
Fixing clap compilation by refering to commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ ansi_term = "0.12.1"
 tabular = "0.1.4"
 wild = "2.0.4"
 walkdir = "2.3.1"
-clap = "3.0.0-beta.1"
+clap = { git = "https://github.com/clap-rs/clap/", rev = "a827ad5" }


### PR DESCRIPTION
Added to the `Cargo.toml`
```toml
clap = { git = "https://github.com/clap-rs/clap/", rev = "a827ad5" }
```

That was before the clap breaking change that broke `durt` the downside
of refering to a specific commit hash is not being able to publish it to
[crates.io](https://crates.io), however, that was already not possible due to the compile
error.

Serves as a temporary fix while `clap` _3.0_ is not released.